### PR TITLE
Remove octal escape sequences

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 var QRCode = require('./../vendor/QRCode'),
     QRErrorCorrectLevel = require('./../vendor/QRCode/QRErrorCorrectLevel'),
-    black = "\033[40m  \033[0m",
-    white = "\033[47m  \033[0m",
+    black = "\x1b[40m  \x1b[0m",
+    white = "\x1b[47m  \x1b[0m",
     toCell = function (isBlack) {
         return isBlack ? black : white;
     },


### PR DESCRIPTION
I'm trying to build a Discord bot with rollup, and these deprecated octal escape sequences are breaking the build, since they don't work in strict mode. This PR replaces them with their hexadecimal equivalents.